### PR TITLE
Initialize count

### DIFF
--- a/seqtest.c
+++ b/seqtest.c
@@ -720,6 +720,7 @@ main(int argc, char **argv)
 	sdly_min = sdly_max = 0;
 	rintvl = 1;
 	nthreads = 1;
+	count = 0;
 	mode = 0;
 
 	/* initialize the timer */


### PR DESCRIPTION
In server mode, even though samples are not collected, the count can
be filled with garbage causing a very large calloc to occur.
