### PR TITLE
Add -Wall -Werror and fix source accordingly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
+UNAME		=$(shell uname)
 
-all:
-	$(MAKE) build-`uname`
-build-Darwin:
-	$(CC) seqtest.c -o seqtest
+CFLAGS_COMMON	=-std=gnu99 -Wall -Werror
+CFLAGS_Linux	=-D _GNU_SOURCE -D _XOPEN_SOURCE=700
+CFLAGS_SunOS	=-D __EXTENSIONS__ -D _XOPEN_SOURCE=600
+CFLAGS		+=$(CFLAGS_COMMON) $(CFLAGS_$(UNAME))
 
-build-Linux:
-	$(CC) -std=gnu99 seqtest.c -o seqtest -D _GNU_SOURCE -D _XOPEN_SOURCE=700  -lrt -lm
+LDFLAGS_Linux	=-lrt -lm
+LDFLAGS_SunOS	=-lnsl -lsocket -lm -lrt -lpthread
+LDFLAGS		+=$(LDFLAGS_$(UNAME))
 
-build-SunOS:
-	$(CC) -std=gnu99 seqtest.c -o seqtest -D __EXTENSIONS__ -D _XOPEN_SOURCE=600 -lnsl -lsocket -lm -lrt -lpthread
- 
+all: seqtest
+
+seqtest: seqtest.c
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 clean:
 	$(RM) seqtest


### PR DESCRIPTION
Add `-Wall -Werror` flags.

* I took this opportunity to tidy up the Makefile.
* The inttype macros cause unsightly line breaks. It would be cleaner to put error msgs in their own functions or some other similar refactor. For now I just broke the lines.
* I removed the `randtime()` call in `ndealy()` because its value is never used. From what I can tell the code used to use this as an estimate of `randtime()` duration to avoid excessively calling into `gethrtime()`. Then the code was changed to use a sleep but `rtime` was never removed. From what I can tell there is no use for `randtime()` anymore and it can be removed. But I left it alone for now.