### PR TITLE
Add spin loop recv option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 UNAME		=$(shell uname)
 
-CFLAGS_COMMON	=-std=gnu99 -Wall -Werror
+# -pthread needed for MT errno
+CFLAGS_COMMON	=-std=gnu99 -Wall -Werror -pthread
 CFLAGS_Linux	=-D _GNU_SOURCE -D _XOPEN_SOURCE=700
 CFLAGS_SunOS	=-D __EXTENSIONS__ -D _XOPEN_SOURCE=600
 CFLAGS		+=$(CFLAGS_COMMON) $(CFLAGS_$(UNAME))


### PR DESCRIPTION
I want this feature for two reasons:
1. The Solarflare pingpong test has it and this is our replacement for that benchmark tool.
2. The upper-half of the recv() path is different on illumos depending on if you make a blocking call or not. I want to be able to test that path.

This option can reduce latency by 10-14% on SmartOS so I think it's a good feature to have to demonstrate the amount of overhead the blocking call can add.
